### PR TITLE
Read a finite duration with the coarsest time unit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val `teleproto` =
     .settings(Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings): _*)
     .settings(
       name := "teleproto",
-      version := "1.1.1",
+      version := "1.1.2",
       libraryDependencies ++= Seq(
         library.scalaPB          % "protobuf",
         library.scalaPBJson      % Compile,

--- a/src/main/scala/io/moia/protos/teleproto/Reader.scala
+++ b/src/main/scala/io/moia/protos/teleproto/Reader.scala
@@ -111,7 +111,7 @@ object Reader extends LowPriorityReads {
     */
   implicit object FiniteDurationReader extends Reader[PBDuration, FiniteDuration] {
     def read(protobuf: PBDuration): PbResult[FiniteDuration] =
-      PbSuccess(Duration(protobuf.seconds, SECONDS) + Duration(protobuf.nanos.toLong, NANOSECONDS))
+      PbSuccess((Duration(protobuf.seconds, SECONDS) + Duration(protobuf.nanos.toLong, NANOSECONDS)).toCoarsest)
   }
 
   /**


### PR DESCRIPTION
I am annoyed by reading `2000000000 nanoseconds` in the logs...