### PR TITLE
Add compatibility for Scala 2.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,12 +48,12 @@ jobs:
   test:
     <<: *sbtCommand
     environment:
-      SBT_COMMAND: "test"
+      SBT_COMMAND: "+test"
 
   scapegoat:
     <<: *sbtCommand
     environment:
-      SBT_COMMAND: "scapegoat"
+      SBT_COMMAND: "+scapegoat"
 
 workflows:
   version: 2

--- a/build.sbt
+++ b/build.sbt
@@ -69,9 +69,7 @@ lazy val compilerSettings =
         case Some((2, 13)) => scalacOptions_2_13
         case _             => Seq()
       }
-    },
-    unmanagedSourceDirectories.in(Compile) := Seq(scalaSource.in(Compile).value),
-    unmanagedSourceDirectories.in(Test) := Seq(scalaSource.in(Test).value)
+    }
   )
 
 lazy val scalacOptions_2_12 = Seq(

--- a/src/main/scala-2.12/io/moia/protos/teleproto/VersionSpecific.scala
+++ b/src/main/scala-2.12/io/moia/protos/teleproto/VersionSpecific.scala
@@ -1,0 +1,10 @@
+package io.moia.protos.teleproto
+
+import scala.reflect.macros.blackbox
+
+object VersionSpecific {
+  def lookupFactory(c: blackbox.Context)(innerTo: c.universe.Type, to: c.universe.Type): c.universe.Tree = {
+    import c.universe._
+    q"""implicitly[scala.collection.generic.CanBuildFrom[${to.erasure}, $innerTo, $to]]"""
+  }
+}

--- a/src/main/scala-2.13/io/moia/protos/teleproto/VersionSpecific.scala
+++ b/src/main/scala-2.13/io/moia/protos/teleproto/VersionSpecific.scala
@@ -1,0 +1,10 @@
+package io.moia.protos.teleproto
+
+import scala.reflect.macros.blackbox
+
+object VersionSpecific {
+  def lookupFactory(c: blackbox.Context)(innerTo: c.universe.Type, to: c.universe.Type): c.universe.Tree = {
+    import c.universe._
+    q"""implicitly[scala.collection.Factory[$innerTo, $to]]"""
+  }
+}

--- a/src/main/scala/io/moia/protos/teleproto/ReaderImpl.scala
+++ b/src/main/scala/io/moia/protos/teleproto/ReaderImpl.scala
@@ -150,7 +150,7 @@ object ReaderImpl {
 
           matchingParam match {
             case TransformParam(from, to) if from <:< to =>
-              Some(q"val ${termSymbol.name} = protobuf.${termSymbol.name}" -> Compatibility.full)
+              Some(q"val ${termSymbol.name} = protobuf.${termSymbol.name}" -> Compatibility.full[Type])
             case TransformParam(from, to) if from <:< weakTypeOf[Option[_]] && !(to <:< weakTypeOf[Option[_]]) =>
               val innerFrom = innerType(c)(from)
               Some(assign(withImplicitReader(c)(innerFrom, to) { readerExpr =>
@@ -158,14 +158,14 @@ object ReaderImpl {
               }))
             case TransformParam(from, to) if from <:< weakTypeOf[Option[_]] && (to <:< weakTypeOf[Option[_]]) =>
               val innerFrom = innerType(c)(from)
-              val innerTo   = innerType(c)(to)
+              val innerTo = innerType(c)(to)
               Some(assign(withImplicitReader(c)(innerFrom, innerTo) { readerExpr =>
                 q"""$mapping.Reader.optional[$innerFrom, $innerTo](protobuf.${termSymbol.name}, $path)($readerExpr)"""
               }))
 
             case TransformParam(from, to) if from <:< weakTypeOf[Seq[_]] && to <:< weakTypeOf[Iterable[_]] =>
               val innerFrom = innerType(c)(from)
-              val innerTo   = innerType(c)(to)
+              val innerTo = innerType(c)(to)
               Some(assign(withImplicitReader(c)(innerFrom, innerTo) { readerExpr =>
                 // sequence also needs an implicit collection generator which must be looked up since the implicit for the value reader is passed explicitly
                 val canBuildFrom = q"""implicitly[scala.collection.Factory[$innerTo, $to]]"""
@@ -176,9 +176,9 @@ object ReaderImpl {
                 q"""$mapping.Reader.transform[$from, $to](protobuf.${termSymbol.name}, $path)($readerExpr)"""
               }))
             case ExplicitDefaultParam(expr) =>
-              Some(q"val ${termSymbol.name} = $expr" -> Compatibility.full)
+              Some(q"val ${termSymbol.name} = $expr" -> Compatibility.full[Type])
             case SkippedDefaultParam(_) =>
-              None
+              Option.empty[(Tree, Compatibility[Type])]
           }
       }
     }

--- a/src/main/scala/io/moia/protos/teleproto/ReaderImpl.scala
+++ b/src/main/scala/io/moia/protos/teleproto/ReaderImpl.scala
@@ -15,6 +15,7 @@
  */
 
 package io.moia.protos.teleproto
+
 import scala.collection.compat._
 import scala.reflect.macros.blackbox
 
@@ -158,17 +159,17 @@ object ReaderImpl {
               }))
             case TransformParam(from, to) if from <:< weakTypeOf[Option[_]] && (to <:< weakTypeOf[Option[_]]) =>
               val innerFrom = innerType(c)(from)
-              val innerTo = innerType(c)(to)
+              val innerTo   = innerType(c)(to)
               Some(assign(withImplicitReader(c)(innerFrom, innerTo) { readerExpr =>
                 q"""$mapping.Reader.optional[$innerFrom, $innerTo](protobuf.${termSymbol.name}, $path)($readerExpr)"""
               }))
 
             case TransformParam(from, to) if from <:< weakTypeOf[Seq[_]] && to <:< weakTypeOf[Iterable[_]] =>
               val innerFrom = innerType(c)(from)
-              val innerTo = innerType(c)(to)
+              val innerTo   = innerType(c)(to)
               Some(assign(withImplicitReader(c)(innerFrom, innerTo) { readerExpr =>
                 // sequence also needs an implicit collection generator which must be looked up since the implicit for the value reader is passed explicitly
-                val canBuildFrom = q"""implicitly[scala.collection.Factory[$innerTo, $to]]"""
+                val canBuildFrom = VersionSpecific.lookupFactory(c)(innerTo, to)
                 q"""$mapping.Reader.sequence[${to.typeConstructor}, $innerFrom, $innerTo](protobuf.${termSymbol.name}, $path)($canBuildFrom, $readerExpr)"""
               }))
             case TransformParam(from, to) =>

--- a/src/main/scala/io/moia/protos/teleproto/WriterImpl.scala
+++ b/src/main/scala/io/moia/protos/teleproto/WriterImpl.scala
@@ -163,8 +163,7 @@ object WriterImpl {
                   val innerTo   = innerType(c)(to)
                   withImplicitWriter(c)(innerFrom, innerTo) { writerExpr =>
                     // collection also needs an implicit sequence generator which must be looked up since the implicit for the value writer is passed explicitly
-                    val canBuildFrom =
-                      q"""implicitly[scala.collection.Factory[$innerTo, $to]]"""
+                    val canBuildFrom = VersionSpecific.lookupFactory(c)(innerTo, to)
                     q"""$mapping.Writer.collection[$innerFrom, $innerTo, scala.collection.immutable.Seq](model.${param.name})($canBuildFrom, $writerExpr)"""
                   }
                 } else if (from <:< weakTypeOf[IterableOnce[_]] && to <:< weakTypeOf[Seq[_]]) {


### PR DESCRIPTION
In Scala 2.12.x, the current version of teleproto does no longer 
compile, due to the reference to `scala.collection.Factory`.

This pr adds a `VersionSpecific` object that does the right thing :tm:




#### Has the version number been increased?
 - [x] Yes! (or not but it was intended to not increase it)