### PR TITLE
Ignore `unknownFields` property for compatibility check.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val `teleproto` =
     .settings(Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings): _*)
     .settings(
       name := "teleproto",
-      version := "1.4.0",
+      version := "1.5.0",
       libraryDependencies ++= Seq(
         library.scalaPB          % "protobuf",
         library.scalaPBJson      % Compile,

--- a/src/main/scala/io/moia/protos/teleproto/FormatImpl.scala
+++ b/src/main/scala/io/moia/protos/teleproto/FormatImpl.scala
@@ -46,7 +46,13 @@ object FormatImpl {
                                  defaultParameters: Iterable[(TYPE, String)],
                                  surplusClasses: Iterable[(TYPE, String)]) {
 
-    def hasIssues: Boolean = surplusParameters.nonEmpty || defaultParameters.nonEmpty || surplusClasses.nonEmpty
+    // scalaPB 0.10 introduces a field called unknownFields for every proto by default.
+    // See: https://github.com/scalapb/ScalaPB/issues/778 for alternatives.
+    // The application can either choose to map or ignore this property.
+    // A simple workaround for the moment is to ignore this property completely.
+    def unknownFieldProperty(property: (TYPE, String)): Boolean = property._2 == "unknownFields"
+
+    def hasIssues: Boolean = !(surplusParameters ++ defaultParameters ++ surplusClasses).forall(unknownFieldProperty)
 
     def merge(that: Compatibility[TYPE]): Compatibility[TYPE] =
       Compatibility(


### PR DESCRIPTION
#### Change Description
scalaPB 0.10 introduces a field called unknownFields for every proto by default.
See: https://github.com/scalapb/ScalaPB/issues/778 for alternatives.
The application can either choose to map or ignore this property.
The compatibility check will emit warnings if the property is not mapped, but will be silent if this is the only compatibility problem.

#### Has the version number been increased?
 - [x] Yes! (or not but it was intended to not increase it)

Fixes #21