### PR TITLE
Move .sbtopts to .jvmopts and remove GC options

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,4 @@
+-Xms512m
+-Xmx2g
+-XX:ReservedCodeCacheSize=256m
+-Djava.awt.headless=true

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,6 +1,0 @@
--J-Xms512m
--J-Xmx2g
--J-XX:+UseConcMarkSweepGC
--J-XX:ReservedCodeCacheSize=256m
--J-XX:+CMSClassUnloadingEnabled
--Djava.awt.headless=true


### PR DESCRIPTION
GC options are specific to JVM versions:
  * `UseConcMarkSweepGC` is deprecated in newer versions
  * It is not available in GraalVM
  * It claseshes with locally defined `SBT_OPTS`



#### Has the version number been increased?
 - [x] No