### PR TITLE
Add PbResult#toOption

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val `teleproto` =
     .settings(Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings): _*)
     .settings(
       name := "teleproto",
-      version := "1.5.0",
+      version := "1.6.0",
       libraryDependencies ++= Seq(
         library.scalaPB          % "protobuf",
         library.scalaPBJson      % Compile,

--- a/src/main/scala/io/moia/protos/teleproto/PbResult.scala
+++ b/src/main/scala/io/moia/protos/teleproto/PbResult.scala
@@ -39,6 +39,8 @@ sealed trait PbResult[+T] {
   def withPathPrefix(prefix: String): PbResult[T]
 
   def toTry: Try[T]
+
+  def toOption: Option[T]
 }
 
 object PbResult {
@@ -80,6 +82,8 @@ final case class PbSuccess[T](value: T) extends PbResult[T] {
   override def withPathPrefix(prefix: String): PbSuccess[T] = this
 
   def toTry: Try[T] = Success(get)
+
+  def toOption: Option[T] = Some(get)
 }
 
 /**
@@ -114,6 +118,8 @@ final case class PbFailure(errors: Seq[(String, String)]) extends PbResult[Nothi
     errors.map(e => s"${e._1} ${e._2}".trim).mkString(" ")
 
   def toTry: Try[Nothing] = Failure(new Exception(toString))
+
+  def toOption: Option[Nothing] = None
 }
 
 object PbFailure {

--- a/src/test/scala/io/moia/protos/teleproto/PbResultTest.scala
+++ b/src/test/scala/io/moia/protos/teleproto/PbResultTest.scala
@@ -41,10 +41,28 @@ class PbResultTest extends UnitTest {
     }
   }
 
+  "PbSuccess" should {
+    "be converted to Some with toOption" in {
+      PbSuccess("success").toOption shouldBe Some("success")
+    }
+
+    "be converted to Success with toTry" in {
+      PbSuccess("success").toTry shouldBe Success("success")
+    }
+  }
+
   "PbFailure" should {
     "have constructor from Throwable" in {
       val message = "Malformed payload"
       PbFailure.fromThrowable(new Exception(message)) shouldBe PbFailure(message)
+    }
+
+    "be converted to None with toOption" in {
+      PbFailure("error").toOption shouldBe None
+    }
+
+    "be converted to Failure with toTry" in {
+      PbFailure("error").toTry.failure.exception.getMessage shouldBe "error"
     }
   }
 }

--- a/src/test/scala/io/moia/protos/teleproto/UnitTest.scala
+++ b/src/test/scala/io/moia/protos/teleproto/UnitTest.scala
@@ -1,7 +1,8 @@
 package io.moia.protos.teleproto
 
 import org.scalatest.OptionValues
+import org.scalatest.TryValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-trait UnitTest extends AnyWordSpec with Matchers with OptionValues
+trait UnitTest extends AnyWordSpec with Matchers with OptionValues with TryValues


### PR DESCRIPTION
I needed this convertion, so decided to add it.

#### Has the version number been increased?
 - [x] Yes! (or not but it was intended to not increase it)

Should I also [bump the version](https://github.com/moia-dev/teleproto/blob/master/build.sbt#L14) to `1.6.0`?