### PR TITLE
Update to Scala 2.13.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 lib_managed
 project/project
 target
+/.bsp/sbt.json
 
 # Worksheets (Eclipse or IntelliJ)
 *.sc

--- a/build.sbt
+++ b/build.sbt
@@ -172,7 +172,9 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[Problem]("io.moia.protos.teleproto.WriterImpl*"),
     // PbResult is a sealed trait so linking from Scala should be fine.
     // Also, this method was added before introducing MiMa.
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.moia.protos.teleproto.PbResult.toOption")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.moia.protos.teleproto.PbResult.toOption"),
+    // Writer.Mapped was an unused private class.
+    ProblemFilters.exclude[MissingClassProblem]("io.moia.protos.teleproto.Writer$Mapped")
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val library = new {
     val scalaCheck         = "1.15.2"
     val scalaTest          = "3.2.2"
     val scalaTestPlusCheck = "3.2.2.0"
-    val scapeGoat          = "1.4.6"
+    val scapeGoat          = "1.4.7"
   }
 
   val scalaPB            = "com.thesamet.scalapb" %% "scalapb-runtime" % Version.scalaPB
@@ -63,20 +63,19 @@ lazy val commonSettings = Seq.concat(
   mimaSettings
 )
 
-lazy val compilerSettings =
-  Seq(
-    scalaVersion := crossScalaVersions.value.head,
-    crossScalaVersions := List("2.13.3", "2.12.12"),
-    mappings.in(Compile, packageBin) +=
-      baseDirectory.in(ThisBuild).value / "LICENSE" -> "LICENSE",
-    scalacOptions ++= {
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 12)) => scalacOptions_2_12
-        case Some((2, 13)) => scalacOptions_2_13
-        case _             => Seq()
-      }
+lazy val compilerSettings = Seq(
+  scalaVersion := crossScalaVersions.value.head,
+  crossScalaVersions := List("2.13.4", "2.12.12"),
+  mappings.in(Compile, packageBin) +=
+    baseDirectory.in(ThisBuild).value / "LICENSE" -> "LICENSE",
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 12)) => scalacOptions_2_12
+      case Some((2, 13)) => scalacOptions_2_13
+      case _             => Seq()
     }
-  )
+  }
+)
 
 lazy val scalacOptions_2_12 = Seq(
   "-unchecked",
@@ -103,6 +102,7 @@ lazy val scalacOptions_2_13 = Seq(
   "-encoding",
   "UTF-8",
   "-Xfatal-warnings",
+  "-Xlint",
   "-Ywarn-dead-code",
   "-Ymacro-annotations"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val `teleproto` =
     .settings(Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings): _*)
     .settings(
       name := "teleproto",
-      version := "1.10.0",
+      version := "1.11.0",
       libraryDependencies ++= Seq(
         library.scalaPB            % "protobuf",
         library.scalaPBJson        % Compile,

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val commonSettings = Seq.concat(
 
 lazy val compilerSettings = Seq(
   scalaVersion := crossScalaVersions.value.head,
-  crossScalaVersions := List("2.13.4", "2.12.12"),
+  crossScalaVersions := List("2.13.4", "2.12.13"),
   mappings.in(Compile, packageBin) +=
     baseDirectory.in(ThisBuild).value / "LICENSE" -> "LICENSE",
   scalacOptions ++= {

--- a/build.sbt
+++ b/build.sbt
@@ -153,13 +153,11 @@ lazy val scalaFmtSettings =
     scalafmtOnCompile := true
   )
 
-lazy val scapegoatSettings =
-  Seq(
-    scapegoatVersion in ThisBuild := library.Version.scapeGoat,
-    scapegoatDisabledInspections := Seq("FinalModifierOnCaseClass", "VariableShadowing"),
-    // do not check generated files
-    scapegoatIgnoredFiles := Seq(".*/src_managed/.*")
-  )
+lazy val scapegoatSettings = Seq(
+  scapegoatVersion in ThisBuild := library.Version.scapeGoat,
+  // do not check generated files
+  scapegoatIgnoredFiles := Seq(".*/src_managed/.*")
+)
 
 lazy val mimaSettings = Seq(
   // First 2.13 release of 1.x

--- a/src/main/scala/io/moia/protos/teleproto/MigrationImpl.scala
+++ b/src/main/scala/io/moia/protos/teleproto/MigrationImpl.scala
@@ -139,8 +139,8 @@ class MigrationImpl(val c: blackbox.Context) extends FormatImpl {
     // collect the expressions for the constructor of the target proto
     val passedExpressions =
       paramMigrations.map {
-        case Automatically(tree: Tree, _) => tree
-        case Required(_, _, index, _)     => q"""${args(index)}(pb)"""
+        case Automatically(tree, _)   => tree
+        case Required(_, _, index, _) => q"""${args(index)}(pb)"""
       }
 
     // TargetProto(...)

--- a/src/main/scala/io/moia/protos/teleproto/ProtocolBuffers.scala
+++ b/src/main/scala/io/moia/protos/teleproto/ProtocolBuffers.scala
@@ -17,7 +17,6 @@
 package io.moia.protos.teleproto
 
 import scala.concurrent.Future
-import scala.language.experimental.macros
 
 @SuppressWarnings(Array("all"))
 object ProtocolBuffers {

--- a/src/main/scala/io/moia/protos/teleproto/ReaderImpl.scala
+++ b/src/main/scala/io/moia/protos/teleproto/ReaderImpl.scala
@@ -116,10 +116,10 @@ class ReaderImpl(val c: blackbox.Context) extends FormatImpl {
 
     val mapping = q"io.moia.protos.teleproto"
 
-    /**
-      * For each parameter creates a value assignment with the name of the parameter, e.g.
-      * `val targetParameter = transformationExpression`
-      */
+    /*
+     * For each parameter creates a value assignment with the name of the parameter, e.g.
+     * `val targetParameter = transformationExpression`
+     */
     def valueDefinitions(parameters: List[(TermSymbol, MatchingParam)]): List[Compiled] = {
       parameters.flatMap {
         case (termSymbol, matchingParam) =>
@@ -163,9 +163,9 @@ class ReaderImpl(val c: blackbox.Context) extends FormatImpl {
       }
     }
 
-    /**
-      * Constructs an expression `PbFailure.combine(convertedParameters..)` for all transformed parameters (could fail).
-      */
+    /*
+     * Constructs an expression `PbFailure.combine(convertedParameters..)` for all transformed parameters (could fail).
+     */
     def forLoop(parameters: List[(TermSymbol, MatchingParam)], cons: Tree): Tree =
       parameters match {
         case Nil =>
@@ -184,9 +184,9 @@ class ReaderImpl(val c: blackbox.Context) extends FormatImpl {
           }
       }
 
-    /**
-      * Constructs an expression `PbFailure(...)` that contains all errors for all failed parameter transformations.
-      */
+    /*
+     * Constructs an expression `PbFailure(...)` that contains all errors for all failed parameter transformations.
+     */
     def combineErrors(parameters: List[(TermSymbol, MatchingParam)]): Tree = {
       val convertedValues =
         parameters.flatMap {

--- a/src/main/scala/io/moia/protos/teleproto/VersionedModelReader.scala
+++ b/src/main/scala/io/moia/protos/teleproto/VersionedModelReader.scala
@@ -148,7 +148,7 @@ object VersionedModelReader {
       * Note: This method has a default implementation that forwards to the other `fromJson` and ignores `parser`.
       * This is done for binary compatibility but is overridden in the implementation.
       */
-    def fromJson(jsonString: String, parser: Parser): Try[PbResult[Model]] = fromJson(jsonString)
+    def fromJson(jsonString: String, unusedParser: Parser): Try[PbResult[Model]] = fromJson(jsonString)
   }
 
   def apply[Version, DetachedModel](

--- a/src/main/scala/io/moia/protos/teleproto/Writer.scala
+++ b/src/main/scala/io/moia/protos/teleproto/Writer.scala
@@ -16,11 +16,10 @@
 
 package io.moia.protos.teleproto
 
-import java.time.{Instant, LocalTime}
-
 import com.google.protobuf.duration.{Duration => PBDuration}
 import com.google.protobuf.timestamp.Timestamp
 
+import java.time.{Instant, LocalTime}
 import scala.annotation.implicitNotFound
 import scala.collection.compat._
 import scala.collection.immutable.TreeMap
@@ -173,11 +172,6 @@ object Writer extends LowPriorityWrites {
                                              valueWriter: Writer[MV, PV],
                                              ordering: Ordering[PK]): Writer[TreeMap[MK, MV], Map[PK, PV]] =
     (model: TreeMap[MK, MV]) => for ((key, value) <- model) yield (keyWriter.write(key), valueWriter.write(value))
-
-  private class Mapped[M, P, Q](wrapped: Writer[M, P], f: P => Q) extends Writer[M, Q] {
-
-    def write(model: M): Q = f(wrapped.write(model))
-  }
 }
 
 trait LowPriorityWrites extends LowestPriorityWrites {

--- a/src/test/scala/io/moia/protos/teleproto/HierarchicalProtocolBuffersTest.scala
+++ b/src/test/scala/io/moia/protos/teleproto/HierarchicalProtocolBuffersTest.scala
@@ -90,7 +90,7 @@ class HierarchicalProtocolBuffersTest extends UnitTest {
 
     "use an 'explicit' implicit writer before generating a writer for a type in hierarchy of a generated type pair" in {
 
-      @nowarn // unused
+      @nowarn("cat=unused")
       implicit val explicitQuxWriter: Writer[model.Qux, protobuf.Qux] =
         (p: model.Qux) => protobuf.Qux("other text")
 
@@ -113,7 +113,7 @@ class HierarchicalProtocolBuffersTest extends UnitTest {
 
     "use an 'explicit' implicit reader before generating a reader for a type in hierarchy of a generated type pair" in {
 
-      @nowarn // unused
+      @nowarn("cat=unused")
       implicit val explicitQuxReader: Reader[protobuf.Qux, model.Qux] =
         (p: protobuf.Qux) => PbFailure("Used the 'explicit' implicit!")
 

--- a/src/test/scala/io/moia/protos/teleproto/HierarchicalProtocolBuffersTest.scala
+++ b/src/test/scala/io/moia/protos/teleproto/HierarchicalProtocolBuffersTest.scala
@@ -2,6 +2,8 @@ package io.moia.protos.teleproto
 
 import scalapb.GeneratedOneof
 
+import scala.annotation.nowarn
+
 /**
   * Tests correct behaviour of generated mappings regarding hierarchical types
   * where a reader/writer for an inner case class can be generated, too.
@@ -88,6 +90,7 @@ class HierarchicalProtocolBuffersTest extends UnitTest {
 
     "use an 'explicit' implicit writer before generating a writer for a type in hierarchy of a generated type pair" in {
 
+      @nowarn // unused
       implicit val explicitQuxWriter: Writer[model.Qux, protobuf.Qux] =
         (p: model.Qux) => protobuf.Qux("other text")
 
@@ -110,6 +113,7 @@ class HierarchicalProtocolBuffersTest extends UnitTest {
 
     "use an 'explicit' implicit reader before generating a reader for a type in hierarchy of a generated type pair" in {
 
+      @nowarn // unused
       implicit val explicitQuxReader: Reader[protobuf.Qux, model.Qux] =
         (p: protobuf.Qux) => PbFailure("Used the 'explicit' implicit!")
 

--- a/src/test/scala/io/moia/protos/teleproto/ProtocolBuffersMigrationHierarchyTest.scala
+++ b/src/test/scala/io/moia/protos/teleproto/ProtocolBuffersMigrationHierarchyTest.scala
@@ -59,7 +59,7 @@ class ProtocolBuffersMigrationHierarchyTest extends UnitTest {
 
     "prefer a custom nested migration over a generated" in {
 
-      @nowarn // unused
+      @nowarn("cat=unused")
       implicit val upperCasingMatchingSubProtoV1toV2: Migration[MatchingSubProtoV1, MatchingSubProtoV2] =
         Migration[MatchingSubProtoV1, MatchingSubProtoV2](src => MatchingSubProtoV2(src.same.toUpperCase))
 

--- a/src/test/scala/io/moia/protos/teleproto/ProtocolBuffersMigrationHierarchyTest.scala
+++ b/src/test/scala/io/moia/protos/teleproto/ProtocolBuffersMigrationHierarchyTest.scala
@@ -1,5 +1,7 @@
 package io.moia.protos.teleproto
 
+import scala.annotation.nowarn
+
 object ProtocolBuffersMigrationHierarchyTest {
 
   // V2
@@ -57,6 +59,7 @@ class ProtocolBuffersMigrationHierarchyTest extends UnitTest {
 
     "prefer a custom nested migration over a generated" in {
 
+      @nowarn // unused
       implicit val upperCasingMatchingSubProtoV1toV2: Migration[MatchingSubProtoV1, MatchingSubProtoV2] =
         Migration[MatchingSubProtoV1, MatchingSubProtoV2](src => MatchingSubProtoV2(src.same.toUpperCase))
 


### PR DESCRIPTION
This updates to latest Scala `2.13.4` and enforces strict linting (including the new exhaustive pattern match) and more scapegoat inspections.

This breaks binary compatibility (not necessarily). Please see below for my [comment](https://github.com/moia-dev/teleproto/pull/97#discussion_r566052974) and let's discuss.

#### Has the version number been increased?
 - [x] Yes!
 - [ ] No